### PR TITLE
Split RGBFrames

### DIFF
--- a/blinkenleds/Makefile
+++ b/blinkenleds/Makefile
@@ -16,7 +16,7 @@ uart:
 	$(pio_binary) run --target upload -e uart
 	
 upload: 
-	$(pio_binary) run --target upload -e panel_10
+	$(pio_binary) run --target upload -e panel_1
 
 upload_all: 
 	$(pio_binary) run --target upload -e panel_1 -e panel_2 -e panel_3 -e panel_4 -e panel_5 -e panel_6 -e panel_7 -e panel_8 -e panel_9 -e panel_10

--- a/blinkenleds/lib/ProtoBuf/schema.pb.cpp
+++ b/blinkenleds/lib/ProtoBuf/schema.pb.cpp
@@ -18,6 +18,9 @@ PB_BIND(WFrame, WFrame, 2)
 PB_BIND(RGBFrame, RGBFrame, 2)
 
 
+PB_BIND(AudioFrame, AudioFrame, AUTO)
+
+
 PB_BIND(InputEvent, InputEvent, AUTO)
 
 

--- a/octopus/lib/octopus/apps/sprites.ex
+++ b/octopus/lib/octopus/apps/sprites.ex
@@ -10,7 +10,6 @@ defmodule Octopus.Apps.Sprites do
   end
 
   @sprite_sheet Sprite.list_sprite_sheets() |> hd()
-  @max_index 255
   @animation_duration 1000
 
   def name(), do: "Sprites"

--- a/octopus/lib/octopus/protobuf.ex
+++ b/octopus/lib/octopus/protobuf.ex
@@ -36,11 +36,6 @@ defmodule Octopus.Protobuf do
     |> Packet.encode()
   end
 
-  def encode(%RGBFrame{data: data} = rgbframe) when is_binary(data) do
-    %Packet{content: {:rgb_frame, rgbframe}}
-    |> Packet.encode()
-  end
-
   def encode(%AudioFrame{} = audio_frame) do
     %Packet{content: {:audio_frame, audio_frame}}
     |> Packet.encode()
@@ -54,6 +49,26 @@ defmodule Octopus.Protobuf do
   def encode(%FirmwareConfig{} = config) do
     %Packet{content: {:firmware_config, config}}
     |> Packet.encode()
+  end
+
+  def split_and_encode(%RGBFrame{data: <<part1::binary-size(960), part2::binary>>} = rgbframe) do
+    packet1 =
+      %Packet{content: {:rgb_frame_part1, %RGBFrame{rgbframe | data: part1}}}
+      |> Packet.encode()
+
+    packet2 =
+      %Packet{content: {:rgb_frame_part2, %RGBFrame{rgbframe | data: part2}}}
+      |> Packet.encode()
+
+    [packet1, packet2]
+  end
+
+  def split_and_encode(%RGBFrame{data: <<part1::binary>>} = rgbframe) do
+    packet1 =
+      %Packet{content: {:rgb_frame_part1, %RGBFrame{rgbframe | data: part1}}}
+      |> Packet.encode()
+
+    [packet1]
   end
 
   def decode_firmware_packet(protobuf) when is_binary(protobuf) do

--- a/octopus/lib/octopus/protobuf/schema.pb.ex
+++ b/octopus/lib/octopus/protobuf/schema.pb.ex
@@ -63,6 +63,9 @@ defmodule Octopus.Protobuf.Packet do
     type: Octopus.Protobuf.FirmwareConfig,
     json_name: "firmwareConfig",
     oneof: 0
+
+  field :rgb_frame_part1, 7, type: Octopus.Protobuf.RGBFrame, json_name: "rgbFramePart1", oneof: 0
+  field :rgb_frame_part2, 8, type: Octopus.Protobuf.RGBFrame, json_name: "rgbFramePart2", oneof: 0
 end
 
 defmodule Octopus.Protobuf.Frame do
@@ -92,6 +95,15 @@ defmodule Octopus.Protobuf.RGBFrame do
 
   field :data, 1, type: :bytes, deprecated: false
   field :easing_interval, 2, type: :uint32, json_name: "easingInterval"
+end
+
+defmodule Octopus.Protobuf.AudioFrame do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field :uri, 1, type: :string
+  field :channel, 2, type: :uint32
 end
 
 defmodule Octopus.Protobuf.InputEvent do
@@ -148,13 +160,4 @@ defmodule Octopus.Protobuf.RemoteLog do
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field :message, 1, type: :string, deprecated: false
-end
-
-defmodule Octopus.Protobuf.AudioFrame do
-  @moduledoc false
-
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
-
-  field :uri, 1, type: :string
-  field :channel, 2, type: :uint32
 end

--- a/protobuf/schema.proto
+++ b/protobuf/schema.proto
@@ -15,8 +15,10 @@ message Packet {
     // Events from the input controllers
     InputEvent input_event = 6;
 
-    // Configures firmware, for internal use only
+    // ** Internal use only **
     FirmwareConfig firmware_config = 1; 
+    RGBFrame rgb_frame_part1 = 7;
+    RGBFrame rgb_frame_part2 = 8;
   }
 }
 


### PR DESCRIPTION
Splits the RGBFrame into two part to avoid exeeding MTU. This is needed untill the firmware supports UDP fragmentation.