### PR TITLE
update octopus install docs

### DIFF
--- a/octopus/README.md
+++ b/octopus/README.md
@@ -16,9 +16,10 @@ On Linux you need:
 - Clone repository `git clone https://github.com/blinkenlights/polychrome`
 - Change directory `cd polychrome/octopus`
 - Run `mix setup` to install and setup dependencies
+- When running for the fist time create and migrate the database by running `mix ecto.create` and then `mix ecto.migrate`
 - Start the server with `iex -S mix phx.server`
 
-Octopus should now be reachable on [`localhost:4000`](http://localhost:4000). 
+Octopus should now be reachable on [`localhost:4000`](http://localhost:4000).
 
 Start the "UDP Server" app to receive external frames on UDP port 2342
 


### PR DESCRIPTION
When I was setting up the project I run into errors. I needed to manually run both commands mentioned in the changes to get it working. Running `mix ecto.migrate` is probably not necessary to add here, since it runs automatically when starting the server. I added it to the docs nevertheless. 