### PR TITLE
fix frontmatter header in command file

### DIFF
--- a/.cursor/commands/rewrite-unpushed-commit-messages-de.md
+++ b/.cursor/commands/rewrite-unpushed-commit-messages-de.md
@@ -1,3 +1,6 @@
+---                                                                                                                                                                                                                  
+description: Rewrite unpushed commit messages into German                                                                                                                                                            
+---
 # Ungepushte Commits: Commit-Messages auf Deutsch umschreiben
 
 Für alle lokalen Git-Commits, die noch nicht nach `origin` gepusht wurden: analysiere die Änderungen jedes Commits und ersetze die Commit-Message durch eine präzise deutsche Message, die den Inhalt des Commits zusammenfasst.


### PR DESCRIPTION
minor fix for the error
`rewrite-unpushed-commit-messages-de.md: Failed to parse command file: missing or invalid frontmatter`